### PR TITLE
fix durability ping options not persisting

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/commands/DurabilityPingCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/commands/DurabilityPingCommand.java
@@ -139,9 +139,11 @@ public class DurabilityPingCommand extends AbstractCommand {
     private void setScoreboardTag(Player player, DuraPingOption option, String value) {
         if (value.equals("true")) {
             player.addScoreboardTag(option.getScoreboardTag());
-            return;
+        } else {
+            player.removeScoreboardTag(option.getScoreboardTag());
         }
-        player.removeScoreboardTag(option.getScoreboardTag());
+        
+        player.addScoreboardTag("dp_customized");
     }
 
     private void setDisplayTag(Player player, String type) {


### PR DESCRIPTION
When a player used `/durabilityping` to disable any of the ping options, they would reset on relog. Looking at the code, it appears `dp_customized` wasn't being set so the values were being reset to default. This only affected ping options, not display types.