### PR TITLE
Customization tool for invisible and fixed item frames

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
@@ -9,7 +9,6 @@ import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public class FixedItemFrames extends BasePack {

--- a/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
@@ -28,7 +28,7 @@ public class FixedItemFrames extends BasePack {
 			if (((ItemFrame) event.getRightClicked()).isFixed()) return;
 			event.setCancelled(true);
 
-			event.getPlayer().getInventory().getItemInMainHand().setAmount(event.getPlayer().getInventory().getItemInMainHand().getAmount() - 1);
+			event.getPlayer().getInventory().getItemInMainHand().setAmount(event.getPlayer().getInventory().getItemInMainHand().getAmount() - getConfig().getInt("take-item-for-fix"));
 
 			ItemFrame frame = (ItemFrame) event.getRightClicked();
 			frame.setFixed(true);
@@ -38,12 +38,12 @@ public class FixedItemFrames extends BasePack {
 	}
 
 	@EventHandler
-	public void onInteract(PlayerInteractAtEntityEvent event) {
+	public void onInteract(PlayerInteractEntityEvent event) {
 		if (!Permission.FIXED_ITEM_FRAMES.check(event.getPlayer())) return;
-
+        if (Material.getMaterial(getConfig().getString("item-for-unfix")) == null) return;
 		if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
             if (!event.getPlayer().isSneaking()) return;
-            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.SHEARS) return;
+            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.getMaterial(getConfig().getString("item-for-unfix"))) return;
             if (!((ItemFrame) event.getRightClicked()).isFixed()) return;
             event.setCancelled(true);
 

--- a/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
@@ -23,13 +23,21 @@ public class FixedItemFrames extends BasePack {
 
 		if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
 			if (!event.getPlayer().isSneaking()) return;
-			if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.IRON_BARS) return;
+			if (Material.getMaterial(getConfig().getString("item-for-fix")) == null) return;
+			if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.getMaterial(getConfig().getString("item-for-fix"))) return;
 			if (((ItemFrame) event.getRightClicked()).isFixed()) return;
 			event.setCancelled(true);
 
-			event.getPlayer().getInventory().getItemInMainHand().setAmount(event.getPlayer().getInventory().getItemInMainHand().getAmount() - getConfig().getInt("take-item-for-fix"));
-
 			ItemFrame frame = (ItemFrame) event.getRightClicked();
+
+			if (event.getPlayer().getInventory().getItemInMainHand().getAmount() - Math.abs(getConfig().getInt("take-item-for-fix")) < 0) {
+				event.getPlayer().playSound(event.getPlayer().getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1.4f);
+				frame.getWorld().spawnParticle(Particle.ANGRY_VILLAGER, frame.getLocation().add(0, .5, 0), 1, .1, .1, .1, 0);
+				return;
+			}
+
+			event.getPlayer().getInventory().getItemInMainHand().setAmount(event.getPlayer().getInventory().getItemInMainHand().getAmount() - Math.abs(getConfig().getInt("take-item-for-fix")));
+
 			frame.setFixed(true);
 			frame.getWorld().spawnParticle(Particle.DAMAGE_INDICATOR, frame.getLocation().add(0, .5, 0), 1, .1, .1, .1, 0);
 			event.getPlayer().playSound(event.getPlayer().getLocation(), Sound.BLOCK_CHEST_LOCKED, 1, 1.4f);
@@ -39,9 +47,9 @@ public class FixedItemFrames extends BasePack {
 	@EventHandler
 	public void onInteract(PlayerInteractEntityEvent event) {
 		if (!Permission.FIXED_ITEM_FRAMES.check(event.getPlayer())) return;
-        if (Material.getMaterial(getConfig().getString("item-for-unfix")) == null) return;
 		if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
             if (!event.getPlayer().isSneaking()) return;
+			if (Material.getMaterial(getConfig().getString("item-for-unfix")) == null) return;
             if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.getMaterial(getConfig().getString("item-for-unfix"))) return;
             if (!((ItemFrame) event.getRightClicked()).isFixed()) return;
             event.setCancelled(true);

--- a/src/main/java/me/teakivy/teakstweaks/packs/invisibleitemframes/InvisibleItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/invisibleitemframes/InvisibleItemFrames.java
@@ -23,7 +23,8 @@ public class InvisibleItemFrames extends BasePack {
 
         if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
             if (!event.getPlayer().isSneaking()) return;
-            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.SHEARS) return;
+            if (Material.getMaterial(getConfig().getString("item-for-invisible")) == null) return;
+            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.getMaterial(getConfig().getString("item-for-invisible"))) return;
             event.setCancelled(true);
 
             ItemFrame frame = (ItemFrame) event.getRightClicked();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -389,7 +389,7 @@ packs:
     enabled: false
     # Item for make fixed item frame (Default: IRON_BARS)
     item-for-fix: IRON_BARS
-    # How many it would take for make fixed item frame (Default: 1)
+    # How many it would take for make fixed item frame (Default: 1) (Max: 64) (Checks the items ONLY in your mainhand)
     take-item-for-fix: 1
     # Item for make unfixed item frame (Default: BRUSH)
     item-for-unfix: BRUSH

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -387,6 +387,9 @@ packs:
   # teakstweaks.fixed-item-frames
   fixed-item-frames:
     enabled: false
+    item-for-fix: IRON_BARS # Item for make fixed item frame
+    take-item-for-fix: 1 # How many it would take for make fixed item frame
+    item-for-unfix: BRUSH # Item for make unfixed item frame
 
   # Graves
   # When a player dies, a grave is made at their location containing all their items. Right-click the grave to receive your items,
@@ -475,6 +478,8 @@ packs:
   # teakstweaks.invisible-item-frames
   invisible-item-frames:
     enabled: false
+    item-for-invisible: SHEARS # Item for make invisible item frame
+
 
   # Item Averages
   # Adds a marker that tracks items flowing past it for 2 minutes, then calculates how many of each item will run through per hour

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -387,9 +387,12 @@ packs:
   # teakstweaks.fixed-item-frames
   fixed-item-frames:
     enabled: false
-    item-for-fix: IRON_BARS # Item for make fixed item frame
-    take-item-for-fix: 1 # How many it would take for make fixed item frame
-    item-for-unfix: BRUSH # Item for make unfixed item frame
+    # Item for make fixed item frame (Default: IRON_BARS)
+    item-for-fix: IRON_BARS
+    # How many it would take for make fixed item frame (Default: 1)
+    take-item-for-fix: 1
+    # Item for make unfixed item frame (Default: BRUSH)
+    item-for-unfix: BRUSH
 
   # Graves
   # When a player dies, a grave is made at their location containing all their items. Right-click the grave to receive your items,
@@ -478,7 +481,8 @@ packs:
   # teakstweaks.invisible-item-frames
   invisible-item-frames:
     enabled: false
-    item-for-invisible: SHEARS # Item for make invisible item frame
+    # Item for make invisible item frame (Default: SHEARS)
+    item-for-invisible: SHEARS
 
 
   # Item Averages


### PR DESCRIPTION
Added item customization for invisible and fixed item frames, 
Fixes that when unfixing the item was put in the item frame.
And also the ability to customize the number of items to be removed when fixing item frame