### PR TITLE
Quick commands for additional workstations

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/AnvilQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/AnvilQuickCommand.java
@@ -1,0 +1,31 @@
+package me.teakivy.teakstweaks.packs.quickcommands;
+
+import me.teakivy.teakstweaks.utils.command.AbstractCommand;
+import me.teakivy.teakstweaks.utils.command.CommandType;
+import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
+import me.teakivy.teakstweaks.utils.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+
+import java.util.List;
+
+public class AnvilQuickCommand {
+
+    public void register() {
+        new AnvilQuickCommand.AnvilCommand().register();
+    }
+
+
+    class AnvilCommand extends AbstractCommand {
+        public AnvilCommand() {
+            super(CommandType.PLAYER_ONLY, "quick-commands", "anvil", Permission.COMMAND_ANVIL, List.of("anvil"), "quick_commands.anvil");
+        }
+
+        @Override
+        public void playerCommand(PlayerCommandEvent event) {
+            Player target = event.getPlayer();
+
+            target.openInventory(MenuType.ANVIL.create(target));
+        }
+    }
+}

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/CartographyTableQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/CartographyTableQuickCommand.java
@@ -1,0 +1,31 @@
+package me.teakivy.teakstweaks.packs.quickcommands;
+
+import me.teakivy.teakstweaks.utils.command.AbstractCommand;
+import me.teakivy.teakstweaks.utils.command.CommandType;
+import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
+import me.teakivy.teakstweaks.utils.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+
+import java.util.List;
+
+public class CartographyTableQuickCommand {
+
+    public void register() {
+        new CartographyTableQuickCommand.CartographyTable().register();
+    }
+
+
+    class CartographyTable extends AbstractCommand {
+        public CartographyTable() {
+            super(CommandType.PLAYER_ONLY, "quick-commands", "cartographytable", Permission.COMMAND_CARTOGRAPHYTABLE, List.of("cartography"), "quick_commands.cartographytable");
+        }
+
+        @Override
+        public void playerCommand(PlayerCommandEvent event) {
+            Player target = event.getPlayer();
+
+            target.openInventory(MenuType.CARTOGRAPHY_TABLE.create(target));
+        }
+    }
+}

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/CraftingTableQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/CraftingTableQuickCommand.java
@@ -5,6 +5,7 @@ import me.teakivy.teakstweaks.utils.command.CommandType;
 import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
 import me.teakivy.teakstweaks.utils.permission.Permission;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
 
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class CraftingTableQuickCommand {
         public void playerCommand(PlayerCommandEvent event) {
             Player target = event.getPlayer();
 
-            target.openWorkbench(null, true);
+            target.openInventory(MenuType.CRAFTING.create(target));
         }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/GrindstoneQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/GrindstoneQuickCommand.java
@@ -1,0 +1,31 @@
+package me.teakivy.teakstweaks.packs.quickcommands;
+
+import me.teakivy.teakstweaks.utils.command.AbstractCommand;
+import me.teakivy.teakstweaks.utils.command.CommandType;
+import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
+import me.teakivy.teakstweaks.utils.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+
+import java.util.List;
+
+public class GrindstoneQuickCommand {
+
+    public void register() {
+        new GrindstoneQuickCommand.GrindstoneCommand().register();
+    }
+
+
+    class GrindstoneCommand extends AbstractCommand {
+        public GrindstoneCommand() {
+            super(CommandType.PLAYER_ONLY, "quick-commands", "grindstone", Permission.COMMAND_GRINDSTONE, List.of("grindstone"), "quick_commands.grindstone");
+        }
+
+        @Override
+        public void playerCommand(PlayerCommandEvent event) {
+            Player target = event.getPlayer();
+
+            target.openInventory(MenuType.GRINDSTONE.create(target));
+        }
+    }
+}

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/LoomQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/LoomQuickCommand.java
@@ -1,0 +1,31 @@
+package me.teakivy.teakstweaks.packs.quickcommands;
+
+import me.teakivy.teakstweaks.utils.command.AbstractCommand;
+import me.teakivy.teakstweaks.utils.command.CommandType;
+import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
+import me.teakivy.teakstweaks.utils.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+
+import java.util.List;
+
+public class LoomQuickCommand {
+
+    public void register() {
+        new LoomQuickCommand.LoomCommand().register();
+    }
+
+
+    class LoomCommand extends AbstractCommand {
+        public LoomCommand() {
+            super(CommandType.PLAYER_ONLY, "quick-commands", "loom", Permission.COMMAND_LOOM, List.of("loom"), "quick_commands.loom");
+        }
+
+        @Override
+        public void playerCommand(PlayerCommandEvent event) {
+            Player target = event.getPlayer();
+
+            target.openInventory(MenuType.LOOM.create(target));
+        }
+    }
+}

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
@@ -2,6 +2,7 @@ package me.teakivy.teakstweaks.packs.quickcommands;
 
 import me.teakivy.teakstweaks.packs.BasePack;
 import me.teakivy.teakstweaks.packs.PackType;
+import me.teakivy.teakstweaks.packs.doubleshulkershells.DoubleShulkers;
 import org.bukkit.Material;
 
 import java.util.List;
@@ -45,6 +46,10 @@ public class QuickCommands extends BasePack {
 
         if (getConfig().getBoolean("craftingtable")) {
             new CraftingTableQuickCommand().register();
+        }
+
+        if (getConfig().getBoolean("anvil")) {
+            new AnvilQuickCommand().register();
         }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
@@ -51,5 +51,9 @@ public class QuickCommands extends BasePack {
         if (getConfig().getBoolean("anvil")) {
             new AnvilQuickCommand().register();
         }
+
+        if (getConfig().getBoolean("cartographytable")) {
+            new CartographyTableQuickCommand().register();
+        }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
@@ -63,5 +63,9 @@ public class QuickCommands extends BasePack {
         if (getConfig().getBoolean("loom")) {
             new LoomQuickCommand().register();
         }
+
+        if (getConfig().getBoolean("smithingtable")) {
+            new SmithingTableQuickCommand().register();
+        }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
@@ -59,5 +59,9 @@ public class QuickCommands extends BasePack {
         if (getConfig().getBoolean("grindstone")) {
             new GrindstoneQuickCommand().register();
         }
+
+        if (getConfig().getBoolean("loom")) {
+            new LoomQuickCommand().register();
+        }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/QuickCommands.java
@@ -55,5 +55,9 @@ public class QuickCommands extends BasePack {
         if (getConfig().getBoolean("cartographytable")) {
             new CartographyTableQuickCommand().register();
         }
+
+        if (getConfig().getBoolean("grindstone")) {
+            new GrindstoneQuickCommand().register();
+        }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/SmithingTableQuickCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/quickcommands/SmithingTableQuickCommand.java
@@ -1,0 +1,31 @@
+package me.teakivy.teakstweaks.packs.quickcommands;
+
+import me.teakivy.teakstweaks.utils.command.AbstractCommand;
+import me.teakivy.teakstweaks.utils.command.CommandType;
+import me.teakivy.teakstweaks.utils.command.PlayerCommandEvent;
+import me.teakivy.teakstweaks.utils.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+
+import java.util.List;
+
+public class SmithingTableQuickCommand {
+
+    public void register() {
+        new SmithingTableQuickCommand.SmithingTableCommand().register();
+    }
+
+
+    class SmithingTableCommand extends AbstractCommand {
+        public SmithingTableCommand() {
+            super(CommandType.PLAYER_ONLY, "quick-commands", "smithingtable", Permission.COMMAND_SMITHINGTABLE, List.of("smith"), "quick_commands.smithingtable");
+        }
+
+        @Override
+        public void playerCommand(PlayerCommandEvent event) {
+            Player target = event.getPlayer();
+
+            target.openInventory(MenuType.SMITHING.create(target));
+        }
+    }
+}

--- a/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
@@ -55,6 +55,7 @@ public enum Permission {
     COMMAND_FLY("command.fly", PermissionType.OP),
     COMMAND_ENDERCHEST("command.enderchest"),
     COMMAND_CRAFTINGTABLE("command.craftingtable"),
+    COMMAND_ANVIL("command.anvil"),
 
     ARMORED_ELYTRA_CREATE("armored-elytra.create"),
     ARMORED_ELYTRA_SEPARATE("armored-elytra.separate"),

--- a/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
@@ -59,6 +59,7 @@ public enum Permission {
     COMMAND_CARTOGRAPHYTABLE("command.cartographytable"),
     COMMAND_GRINDSTONE("command.grindstone"),
     COMMAND_LOOM("command.loom"),
+    COMMAND_SMITHINGTABLE("command.smithingtable"),
 
     ARMORED_ELYTRA_CREATE("armored-elytra.create"),
     ARMORED_ELYTRA_SEPARATE("armored-elytra.separate"),

--- a/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
@@ -58,6 +58,7 @@ public enum Permission {
     COMMAND_ANVIL("command.anvil"),
     COMMAND_CARTOGRAPHYTABLE("command.cartographytable"),
     COMMAND_GRINDSTONE("command.grindstone"),
+    COMMAND_LOOM("command.loom"),
 
     ARMORED_ELYTRA_CREATE("armored-elytra.create"),
     ARMORED_ELYTRA_SEPARATE("armored-elytra.separate"),

--- a/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
@@ -57,6 +57,7 @@ public enum Permission {
     COMMAND_CRAFTINGTABLE("command.craftingtable"),
     COMMAND_ANVIL("command.anvil"),
     COMMAND_CARTOGRAPHYTABLE("command.cartographytable"),
+    COMMAND_GRINDSTONE("command.grindstone"),
 
     ARMORED_ELYTRA_CREATE("armored-elytra.create"),
     ARMORED_ELYTRA_SEPARATE("armored-elytra.separate"),

--- a/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/permission/Permission.java
@@ -56,6 +56,7 @@ public enum Permission {
     COMMAND_ENDERCHEST("command.enderchest"),
     COMMAND_CRAFTINGTABLE("command.craftingtable"),
     COMMAND_ANVIL("command.anvil"),
+    COMMAND_CARTOGRAPHYTABLE("command.cartographytable"),
 
     ARMORED_ELYTRA_CREATE("armored-elytra.create"),
     ARMORED_ELYTRA_SEPARATE("armored-elytra.separate"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -656,6 +656,12 @@ packs:
     # Commands:
     # /anvil (Permission: teakstweaks.command.anvil)
     anvil: true
+    # Cartography Table command
+    # Opens the Cartography Table
+    #
+    # Commands:
+    # /cartography (Permission: teakstweaks.command.cartographytable)
+    cartographytable: true
 
 
   # Real Time Clock

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -668,6 +668,12 @@ packs:
     # Commands:
     # /grindstone (Permission: teakstweaks.command.grindstone)
     grindstone: true
+    # Loom command
+    # Opens a Loom
+    #
+    # Commands:
+    # /loom (Permission: teakstweaks.command.loom)
+    loom: true
 
 
   # Real Time Clock

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -650,6 +650,12 @@ packs:
     # Commands:
     # /craftingtable (Permission: teakstweaks.command.craftingtable)
     craftingtable: true
+    # Anvil command
+    # Opens an anvil, still requires appropriate XP
+    #
+    # Commands:
+    # /anvil (Permission: teakstweaks.command.anvil)
+    anvil: true
 
 
   # Real Time Clock

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -674,6 +674,12 @@ packs:
     # Commands:
     # /loom (Permission: teakstweaks.command.loom)
     loom: true
+    # Smithing Table command
+    # Opens a Smithing Table
+    #
+    # Commands:
+    # /smithingtable (Permission: teakstweaks.command.smithingtable)
+    smithingtable: true
 
 
   # Real Time Clock

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -662,6 +662,12 @@ packs:
     # Commands:
     # /cartography (Permission: teakstweaks.command.cartographytable)
     cartographytable: true
+    # Grindstone command
+    # Opens a Grindstone
+    #
+    # Commands:
+    # /grindstone (Permission: teakstweaks.command.grindstone)
+    grindstone: true
 
 
   # Real Time Clock

--- a/src/main/resources/lang/de.json
+++ b/src/main/resources/lang/de.json
@@ -253,6 +253,11 @@
     "quick_commands.fly.command_description": "Schalte den Flugmodus um.",
     "quick_commands.enderchest.command_description": "Öffne deine Endertruhe.",
     "quick_commands.craftingtable.command_description": "Öffne eine Werkbank.",
+    "quick_commands.anvil.command_description": "Öffne einen Amboss.",
+    "quick_commands.cartographytable.command_description": "Öffne einen Kartentisch.",
+    "quick_commands.grindstone.command_description": "Öffne einen Schleifstein.",
+    "quick_commands.loom.command_description": "Öffne einen Webstuhl.",
+    "quick_commands.smithingtable.command_description": "Öffne einen Schmiedetisch.",
   
     "slime_cream.name": "Schleimcreme",
     "slime_cream.description": "Verwandle Schleimbälle in Magmacreme, indem du auf einen Lavakessel rechtsklickst.<newline>Verwandle Magmacreme in Schleimbälle, indem du auf einen Wasserkessel rechtsklickst.",

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -253,6 +253,11 @@
   "quick_commands.fly.command_description": "Toggle flight.",
   "quick_commands.enderchest.command_description": "Open your Ender Chest.",
   "quick_commands.craftingtable.command_description": "Open a Crafting Table.",
+  "quick_commands.anvil.command_description": "Open an Anvil.",
+  "quick_commands.cartographytable.command_description": "Open a Cartography Table.",
+  "quick_commands.grindstone.command_description": "Open a Grindstone.",
+  "quick_commands.loom.command_description": "Open a Loom.",
+  "quick_commands.smithingtable.command_description": "Open a Smithing Table.",
 
   "slime_cream.name": "Slime Cream",
   "slime_cream.description": "Convert Slime Balls to Magma Cream by right-clicking a lava cauldron.<newline>Convert Magma Cream to Slime Balls by right-clicking a water cauldron.",

--- a/src/main/resources/lang/fi.json
+++ b/src/main/resources/lang/fi.json
@@ -254,6 +254,11 @@
   "quick_commands.fly.command_description": "Kytke lento päälle ja pois.",
   "quick_commands.enderchest.command_description": "Avaa sinun ender-arkkusi.",
   "quick_commands.craftingtable.command_description": "Avaa työpöytä.",
+  "quick_commands.anvil.command_description": "Avaa alasin.",
+  "quick_commands.cartographytable.command_description": "Avaa karttapöytä.",
+  "quick_commands.grindstone.command_description": "Avaa hiomakivi.",
+  "quick_commands.loom.command_description": "Avaa kangaspuut.",
+  "quick_commands.smithingtable.command_description": "Avaa ahjopöytä.",
 
   "slime_cream.name": "Lima voide",
   "slime_cream.description": "Muunna limapallot magma voiteeksi oikea klikkaamalla laava pataa.<newline>Muunna magma voide limapalloiksi oikea klikkaamalla vesi pataa.",

--- a/src/main/resources/lang/fr.json
+++ b/src/main/resources/lang/fr.json
@@ -255,6 +255,11 @@
   "quick_commands.fly.command_description": "Activez/désactivez le vol.",
   "quick_commands.enderchest.command_description": "Ouvrez votre enderchest.",
   "quick_commands.craftingtable.command_description": "Ouvrez une table de craft.",
+  "quick_commands.anvil.command_description": "Ouvrir une enclume.",
+  "quick_commands.cartographytable.command_description": "Ouvrir une table de cartographie.",
+  "quick_commands.grindstone.command_description": "Ouvrir une meule.",
+  "quick_commands.loom.command_description": "Ouvrir un métier à tisser.",
+  "quick_commands.smithingtable.command_description": "Ouvrir une table de forgeron.",
 
   "slime_cream.name": "Crème de Slime",
   "slime_cream.description": "Convertissez des Boules de Slime en Crème de Magma en cliquant avec un chaudron de lave.<newline>Convertissez de la Crème de Magma en Boules de Slime en cliquant avec un chaudron d'eau.",

--- a/src/main/resources/lang/nl.json
+++ b/src/main/resources/lang/nl.json
@@ -252,6 +252,11 @@
   "quick_commands.fly.command_description": "Schakel vliegen in of uit.",
   "quick_commands.enderchest.command_description": "Open je Ender Chest.",
   "quick_commands.craftingtable.command_description": "Open een Werkbank.",
+  "quick_commands.anvil.command_description": "Open een aanbeeld.",
+  "quick_commands.cartographytable.command_description": "Open een kaarttafel.",
+  "quick_commands.grindstone.command_description": "Open een slijpsteen.",
+  "quick_commands.loom.command_description": "Open een weefgetouw.",
+  "quick_commands.smithingtable.command_description": "Open een smederijtafel.",
 
   "slime_cream.name": "Slijmcrème",
   "slime_cream.description": "Verander Slijmballen naar Magma Crème door op een lavaketel te klikken.<newline>Verander Magma Crème naar Slijmballen door op een waterketel te klikken.",

--- a/src/main/resources/lang/pl.json
+++ b/src/main/resources/lang/pl.json
@@ -255,6 +255,11 @@
     "quick_commands.fly.command_description": "Przełącz latanie.",
     "quick_commands.enderchest.command_description": "Otwórz swoją Skrzynię Kresu.",
     "quick_commands.craftingtable.command_description": "Otwórz stół rzemieślniczy.",
+    "quick_commands.anvil.command_description": "Otwórz Kowadło.",
+    "quick_commands.cartographytable.command_description": "Otwórz Stół Kartograficzny.",
+    "quick_commands.grindstone.command_description": "Otwórz Szlifierkę.",
+    "quick_commands.loom.command_description": "Otwórz Krosno.",
+    "quick_commands.smithingtable.command_description": "Otwórz Stół Kowalski.",
   
     "slime_cream.name": "Krem Slime",
     "slime_cream.description": "Zamień kulki slime na krem magmowy, klikając prawym przyciskiem myszy na kocioł z lawą.<newline>Zamień krem magmowy na kulki slime, klikając prawym przyciskiem na kocioł z wodą.",

--- a/src/main/resources/lang/ru.json
+++ b/src/main/resources/lang/ru.json
@@ -252,6 +252,11 @@
   "quick_commands.fly.command_description": "Переключить полёт.",
   "quick_commands.enderchest.command_description": "Открыть свой Эндер-сундук.",
   "quick_commands.craftingtable.command_description": "Открыть Верстак.",
+  "quick_commands.anvil.command_description": "Открыть наковальню.",
+  "quick_commands.cartographytable.command_description": "Открыть картографический стол.",
+  "quick_commands.grindstone.command_description": "Открыть точило.",
+  "quick_commands.loom.command_description": "Открыть ткацкий станок.",
+  "quick_commands.smithingtable.command_description": "Открыть кузнечный стол.",
   
   "slime_cream.name": "Слизневый крем",
   "slime_cream.description": "Нажмите ПКМ со сгустком слизи по котлу с лавой чтобы превратить его в магмовый крем.<newline>Нажмите ПКМ с магмовым кремом по котлу с водой чтобы превратить его в сгусток слизи.",


### PR DESCRIPTION
Added the following quick command for workstations:

- Anvil
- Cartography Table
- Grindstone
- Loom
- Smithing Table

I did not include Enchanting Table due to the need of bookshelves, and overriding the bookshelves being a larger change that would require injecting into the enchant process itself (by my understanding). 

I updated the localization files using AI translations; I can not verify their accuracy. I split each command into it's own commit for easier viewing.

Following the Crafting Table, the config file was updated to default these to all true if quick commands is enabled.

Also updated the Crafting Table command to use the new API instead of the deprecated one.

There is a lot of duplicative architecture that may be worth refactoring at a future time.