### PR TITLE
fix: initialize AdvancementTab before event

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/utils/advancements/AdvancementManager.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/advancements/AdvancementManager.java
@@ -54,6 +54,7 @@ public class AdvancementManager {
         tabs.put("more_mob_heads", tab);
         roots.put("more_mob_heads", root);
 
+        tab.registerAdvancements(root);
         tab.getEventManager().register(tab, PlayerLoadingCompletedEvent.class, event -> {
             tab.showTab(event.getPlayer());
             tab.grantRootAdvancement(event.getPlayer());


### PR DESCRIPTION
This PR fixes https://github.com/teakivy/teaks-tweaks/issues/162.