### PR TITLE
Add new resetCooldown method

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/commands/BackCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/commands/BackCommand.java
@@ -60,6 +60,7 @@ public class BackCommand extends AbstractCommand {
         Bukkit.getScheduler().runTaskLater(TeaksTweaks.getInstance(), () -> {
             if (x != player.getLocation().getBlockX() || y != player.getLocation().getBlockY() || z != player.getLocation().getBlockZ()) {
                 player.sendMessage(getError("teleport_moved"));
+                resetCooldown(player);
                 return;
             }
             Back.tpBack(player);

--- a/src/main/java/me/teakivy/teakstweaks/commands/SpawnCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/commands/SpawnCommand.java
@@ -67,6 +67,7 @@ public class SpawnCommand extends AbstractCommand {
         Bukkit.getScheduler().runTaskLater(TeaksTweaks.getInstance(), () -> {
             if (x != player.getLocation().getBlockX() || y != player.getLocation().getBlockY() || z != player.getLocation().getBlockZ()) {
                 player.sendMessage(getError("teleport_moved"));
+                resetCooldown(player);
                 return;
             }
             Back.backLoc.put(player.getUniqueId(), player.getLocation());

--- a/src/main/java/me/teakivy/teakstweaks/utils/command/AbstractCommand.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/command/AbstractCommand.java
@@ -217,6 +217,10 @@ public abstract class AbstractCommand {
         this.cooldownMap.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
+    public void resetCooldown(Player player) {
+        this.cooldownMap.remove(player.getUniqueId());
+    }
+
     public boolean isOnCooldown(Player player) {
         if (!this.cooldownMap.containsKey(player.getUniqueId())) return false;
         return this.cooldownMap.get(player.getUniqueId()) + (this.cooldownTime * 1000L) > System.currentTimeMillis();


### PR DESCRIPTION
This is to fix #166 the teleport cooldown bug when a player moves and the tp is cancelled.

- Reset cooldown when player moves and teleport is cancelled on /spawn
- Reset cooldown when player moves and teleport is cancelled on /back