### PR TITLE
- Fix #171, resource packs redownloaded on every join

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/packs/paintingpicker/PaintingPicker.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/paintingpicker/PaintingPicker.java
@@ -38,7 +38,7 @@ public class PaintingPicker extends BasePack {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (getConfig().getBoolean("suggest-pack")) {
-            event.getPlayer().addResourcePack(UUID.randomUUID(), resourcePackUrl, hash, "Would You like to install the Unique Painting Items resource pack?", false);
+            event.getPlayer().addResourcePack(UUID.nameUUIDFromBytes(hash), resourcePackUrl, hash, "Would You like to install the Unique Painting Items resource pack?", false);
         }
     }
 

--- a/src/main/java/me/teakivy/teakstweaks/packs/rotationwrench/RotationWrench.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/rotationwrench/RotationWrench.java
@@ -82,7 +82,7 @@ public class RotationWrench extends BasePack {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (getConfig().getBoolean("suggest-pack")) {
-            event.getPlayer().addResourcePack(UUID.randomUUID(), resourcePackUrl, hash, "Would You like to install the Rotation Wrench resource pack?", false);
+            event.getPlayer().addResourcePack(UUID.nameUUIDFromBytes(hash), resourcePackUrl, hash, "Would You like to install the Rotation Wrench resource pack?", false);
         }
     }
 


### PR DESCRIPTION
Change addResourcePack to generate UUID based on the hash of the resource pack instead of being random. This allows the client to know it has downloaded that specific resource pack before. Fix #171 