### PR TITLE
fix: correct XP bottle logic and minor optimizations

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/packs/xpmanagement/XPManagement.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/xpmanagement/XPManagement.java
@@ -3,7 +3,6 @@ package me.teakivy.teakstweaks.packs.xpmanagement;
 import me.teakivy.teakstweaks.packs.BasePack;
 import me.teakivy.teakstweaks.utils.Key;
 import me.teakivy.teakstweaks.utils.XPUtils;
-import me.teakivy.teakstweaks.utils.config.Config;
 import me.teakivy.teakstweaks.utils.permission.Permission;
 import me.teakivy.teakstweaks.utils.register.TTPack;
 import net.kyori.adventure.text.Component;
@@ -120,15 +119,13 @@ public class XPManagement extends BasePack {
 
         if (getConfig().getBoolean("display-amount")) {
             List<Component> lore = new ArrayList<>();
-            lore.add(getText("bottle_contains", insert("return_amount", getConfig().getInt("take-xp-amount"))));
+            lore.add(getText("bottle_contains", insert("return_amount", getConfig().getInt("return-xp-amount"))));
             xpMeta.lore(lore);
         }
 
         PersistentDataContainer data = xpMeta.getPersistentDataContainer();
-        data.set(Key.get("xp_amount"), PersistentDataType.INTEGER, Config.getInt("packs.xp-management.return-xp-amount"));
-        xpBottle.setItemMeta(xpMeta);
-
-        data.set(Key.get("xp_smelt_amount"), PersistentDataType.INTEGER, Config.getInt("packs.xp-management.take-xp-amount"));
+        data.set(Key.get("xp_amount"), PersistentDataType.INTEGER, getConfig().getInt("packs.xp-management.return-xp-amount"));
+        data.set(Key.get("xp_smelt_amount"), PersistentDataType.INTEGER, getConfig().getInt("packs.xp-management.take-xp-amount"));
         xpBottle.setItemMeta(xpMeta);
 
         if (getConfig().getBoolean("sneak-to-bottle-all") && player.isSneaking()) {

--- a/src/main/java/me/teakivy/teakstweaks/utils/XPUtils.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/XPUtils.java
@@ -25,11 +25,11 @@ public class XPUtils {
      */
     public static int getExpAtLevel(int level){
         if(level <= 16){
-            return (int) (Math.pow(level,2) + 6*level);
+            return (int) (level*level + 6*level);
         } else if(level <= 31){
-            return (int) (2.5*Math.pow(level,2) - 40.5*level + 360.0);
+            return (int) (2.5*level*level - 40.5*level + 360.0);
         } else {
-            return (int) (4.5*Math.pow(level,2) - 162.5*level + 2220.0);
+            return (int) (4.5*level*level - 162.5*level + 2220.0);
         }
     }
 


### PR DESCRIPTION
- Corrects the XP bottle lore to use `return-xp-amount` instead of `take-xp-amount`.
- Removes a redundant `setItemMeta` call when creating an XP bottle.
- Replaces `Math.pow(n, 2)` with direct multiplication, `n * n`, for a small optimization.