### PR TITLE
refactor: improve performance and robustness of material lookups

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/CraftableCoralBlocks2x2.java
+++ b/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/CraftableCoralBlocks2x2.java
@@ -27,11 +27,11 @@ public class CraftableCoralBlocks2x2 extends AbstractCraftingTweak {
 
     private void newCoralRecipe(String type) {
         RecipeChoice choice = new RecipeChoice.MaterialChoice(List.of(
-                Material.valueOf(type + "_CORAL"),
-                Material.valueOf(type + "_CORAL_FAN")));
+                Material.matchMaterial(type + "_CORAL"),
+                Material.matchMaterial(type + "_CORAL_FAN")));
 
         ShapedRecipe recipe = new ShapedRecipe(Key.get(type.toLowerCase() + "_coral_2x2"),
-                new ItemStack(Material.valueOf(type.toUpperCase() + "_CORAL_BLOCK")));
+                new ItemStack(Material.matchMaterial(type.toUpperCase() + "_CORAL_BLOCK")));
         recipe.shape("xx", "xx");
         recipe.setIngredient('x', choice);
         addRecipe(recipe);

--- a/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/CraftableCoralBlocks3x3.java
+++ b/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/CraftableCoralBlocks3x3.java
@@ -27,11 +27,11 @@ public class CraftableCoralBlocks3x3 extends AbstractCraftingTweak {
 
     private void newCoralRecipe(String type) {
         RecipeChoice choice = new RecipeChoice.MaterialChoice(List.of(
-                Material.valueOf(type + "_CORAL"),
-                Material.valueOf(type + "_CORAL_FAN")));
+                Material.matchMaterial(type + "_CORAL"),
+                Material.matchMaterial(type + "_CORAL_FAN")));
 
         ShapedRecipe recipe = new ShapedRecipe(Key.get(type.toLowerCase() + "_coral_2x2"),
-                new ItemStack(Material.valueOf(type.toUpperCase() + "_CORAL_BLOCK")));
+                new ItemStack(Material.matchMaterial(type.toUpperCase() + "_CORAL_BLOCK")));
         recipe.shape("xxx", "xxx", "xxx");
         recipe.setIngredient('x', choice);
         addRecipe(recipe);

--- a/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/MoreTrapdoors.java
+++ b/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/MoreTrapdoors.java
@@ -34,9 +34,9 @@ public class MoreTrapdoors extends AbstractCraftingTweak {
     public void newTrapdoorRecipe(String type) {
         Bukkit.removeRecipe(NamespacedKey.minecraft(type.toLowerCase() + "_trapdoor"));
         ShapedRecipe recipe = new ShapedRecipe(Key.get(type.toLowerCase() + "_trapdoors"),
-                new ItemStack(Material.valueOf(type + "_TRAPDOOR"), 12));
+                new ItemStack(Material.matchMaterial(type + "_TRAPDOOR"), 12));
         recipe.shape("xxx", "xxx");
-        recipe.setIngredient('x', Material.valueOf(type + "_PLANKS"));
+        recipe.setIngredient('x', Material.matchMaterial(type + "_PLANKS"));
         addRecipe(recipe);
     }
 

--- a/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/PowderToGlass.java
+++ b/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/PowderToGlass.java
@@ -35,7 +35,7 @@ public class PowderToGlass extends AbstractCraftingTweak {
     }
 
     public void newSmeltableGlass(String color) {
-        FurnaceRecipe recipe = new FurnaceRecipe(Key.get(color.toLowerCase() + "_powder_to_glass"), new ItemStack(Material.valueOf(color + "_STAINED_GLASS")), Material.valueOf(color + "_CONCRETE_POWDER"), 10, 100);
+        FurnaceRecipe recipe = new FurnaceRecipe(Key.get(color.toLowerCase() + "_powder_to_glass"), new ItemStack(Material.matchMaterial(color + "_STAINED_GLASS")), Material.matchMaterial(color + "_CONCRETE_POWDER"), 10, 100);
         addRecipe(recipe);
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/UniversalDyeing.java
+++ b/src/main/java/me/teakivy/teakstweaks/craftingtweaks/recipes/UniversalDyeing.java
@@ -37,22 +37,22 @@ public class UniversalDyeing extends AbstractCraftingTweak {
     }
 
     public void registerNewRecipeType(String inputName) {
-        newDyeingRecipe("black_", inputName, Material.BLACK_DYE, Material.valueOf("BLACK_" + inputName));
-        newDyeingRecipe("blue_", inputName, Material.BLUE_DYE, Material.valueOf("BLUE_" + inputName));
-        newDyeingRecipe("brown_", inputName, Material.BROWN_DYE, Material.valueOf("BROWN_" + inputName));
-        newDyeingRecipe("cyan_", inputName, Material.CYAN_DYE, Material.valueOf("CYAN_" + inputName));
-        newDyeingRecipe("gray_", inputName, Material.GRAY_DYE, Material.valueOf("GRAY_" + inputName));
-        newDyeingRecipe("green_", inputName, Material.GREEN_DYE, Material.valueOf("GREEN_" + inputName));
-        newDyeingRecipe("light_blue_", inputName, Material.LIGHT_BLUE_DYE, Material.valueOf("LIGHT_BLUE_" + inputName));
-        newDyeingRecipe("light_gray_", inputName, Material.LIGHT_GRAY_DYE, Material.valueOf("LIGHT_GRAY_" + inputName));
-        newDyeingRecipe("lime_", inputName, Material.LIME_DYE, Material.valueOf("LIME_" + inputName));
-        newDyeingRecipe("magenta_", inputName, Material.MAGENTA_DYE, Material.valueOf("MAGENTA_" + inputName));
-        newDyeingRecipe("orange_", inputName, Material.ORANGE_DYE, Material.valueOf("ORANGE_" + inputName));
-        newDyeingRecipe("pink_", inputName, Material.PINK_DYE, Material.valueOf("PINK_" + inputName));
-        newDyeingRecipe("purple_", inputName, Material.PURPLE_DYE, Material.valueOf("PURPLE_" + inputName));
-        newDyeingRecipe("red_", inputName, Material.RED_DYE, Material.valueOf("RED_" + inputName));
-        newDyeingRecipe("white_", inputName, Material.WHITE_DYE, Material.valueOf("WHITE_" + inputName));
-        newDyeingRecipe("yellow_", inputName, Material.YELLOW_DYE, Material.valueOf("YELLOW_" + inputName));
+        newDyeingRecipe("black_", inputName, Material.BLACK_DYE, Material.matchMaterial("BLACK_" + inputName));
+        newDyeingRecipe("blue_", inputName, Material.BLUE_DYE, Material.matchMaterial("BLUE_" + inputName));
+        newDyeingRecipe("brown_", inputName, Material.BROWN_DYE, Material.matchMaterial("BROWN_" + inputName));
+        newDyeingRecipe("cyan_", inputName, Material.CYAN_DYE, Material.matchMaterial("CYAN_" + inputName));
+        newDyeingRecipe("gray_", inputName, Material.GRAY_DYE, Material.matchMaterial("GRAY_" + inputName));
+        newDyeingRecipe("green_", inputName, Material.GREEN_DYE, Material.matchMaterial("GREEN_" + inputName));
+        newDyeingRecipe("light_blue_", inputName, Material.LIGHT_BLUE_DYE, Material.matchMaterial("LIGHT_BLUE_" + inputName));
+        newDyeingRecipe("light_gray_", inputName, Material.LIGHT_GRAY_DYE, Material.matchMaterial("LIGHT_GRAY_" + inputName));
+        newDyeingRecipe("lime_", inputName, Material.LIME_DYE, Material.matchMaterial("LIME_" + inputName));
+        newDyeingRecipe("magenta_", inputName, Material.MAGENTA_DYE, Material.matchMaterial("MAGENTA_" + inputName));
+        newDyeingRecipe("orange_", inputName, Material.ORANGE_DYE, Material.matchMaterial("ORANGE_" + inputName));
+        newDyeingRecipe("pink_", inputName, Material.PINK_DYE, Material.matchMaterial("PINK_" + inputName));
+        newDyeingRecipe("purple_", inputName, Material.PURPLE_DYE, Material.matchMaterial("PURPLE_" + inputName));
+        newDyeingRecipe("red_", inputName, Material.RED_DYE, Material.matchMaterial("RED_" + inputName));
+        newDyeingRecipe("white_", inputName, Material.WHITE_DYE, Material.matchMaterial("WHITE_" + inputName));
+        newDyeingRecipe("yellow_", inputName, Material.YELLOW_DYE, Material.matchMaterial("YELLOW_" + inputName));
     }
 
     public void newDyeingRecipe(String colorType, String inputName, Material inputDye, Material output) {
@@ -61,22 +61,22 @@ public class UniversalDyeing extends AbstractCraftingTweak {
         ShapedRecipe recipe = new ShapedRecipe(key, new ItemStack(output, 8));
 
         List<Material> materials = new ArrayList<>();
-        materials.add(Material.valueOf("BLACK_" + inputName));
-        materials.add(Material.valueOf("BLUE_" + inputName));
-        materials.add(Material.valueOf("BROWN_" + inputName));
-        materials.add(Material.valueOf("CYAN_" + inputName));
-        materials.add(Material.valueOf("GRAY_" + inputName));
-        materials.add(Material.valueOf("GREEN_" + inputName));
-        materials.add(Material.valueOf("LIGHT_BLUE_" + inputName));
-        materials.add(Material.valueOf("LIGHT_GRAY_" + inputName));
-        materials.add(Material.valueOf("LIME_" + inputName));
-        materials.add(Material.valueOf("MAGENTA_" + inputName));
-        materials.add(Material.valueOf("ORANGE_" + inputName));
-        materials.add(Material.valueOf("PINK_" + inputName));
-        materials.add(Material.valueOf("PURPLE_" + inputName));
-        materials.add(Material.valueOf("RED_" + inputName));
-        materials.add(Material.valueOf("WHITE_" + inputName));
-        materials.add(Material.valueOf("YELLOW_" + inputName));
+        materials.add(Material.matchMaterial("BLACK_" + inputName));
+        materials.add(Material.matchMaterial("BLUE_" + inputName));
+        materials.add(Material.matchMaterial("BROWN_" + inputName));
+        materials.add(Material.matchMaterial("CYAN_" + inputName));
+        materials.add(Material.matchMaterial("GRAY_" + inputName));
+        materials.add(Material.matchMaterial("GREEN_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_BLUE_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_GRAY_" + inputName));
+        materials.add(Material.matchMaterial("LIME_" + inputName));
+        materials.add(Material.matchMaterial("MAGENTA_" + inputName));
+        materials.add(Material.matchMaterial("ORANGE_" + inputName));
+        materials.add(Material.matchMaterial("PINK_" + inputName));
+        materials.add(Material.matchMaterial("PURPLE_" + inputName));
+        materials.add(Material.matchMaterial("RED_" + inputName));
+        materials.add(Material.matchMaterial("WHITE_" + inputName));
+        materials.add(Material.matchMaterial("YELLOW_" + inputName));
 
         recipe.shape("###", "#o#", "###");
         recipe.setIngredient('#', new RecipeChoice.MaterialChoice(materials));
@@ -93,22 +93,22 @@ public class UniversalDyeing extends AbstractCraftingTweak {
 
 
         List<Material> materials = new ArrayList<>();
-        materials.add(Material.valueOf("BLACK_" + inputName));
-        materials.add(Material.valueOf("BLUE_" + inputName));
-        materials.add(Material.valueOf("BROWN_" + inputName));
-        materials.add(Material.valueOf("CYAN_" + inputName));
-        materials.add(Material.valueOf("GRAY_" + inputName));
-        materials.add(Material.valueOf("GREEN_" + inputName));
-        materials.add(Material.valueOf("LIGHT_BLUE_" + inputName));
-        materials.add(Material.valueOf("LIGHT_GRAY_" + inputName));
-        materials.add(Material.valueOf("LIME_" + inputName));
-        materials.add(Material.valueOf("MAGENTA_" + inputName));
-        materials.add(Material.valueOf("ORANGE_" + inputName));
-        materials.add(Material.valueOf("PINK_" + inputName));
-        materials.add(Material.valueOf("PURPLE_" + inputName));
-        materials.add(Material.valueOf("RED_" + inputName));
-        materials.add(Material.valueOf("WHITE_" + inputName));
-        materials.add(Material.valueOf("YELLOW_" + inputName));
+        materials.add(Material.matchMaterial("BLACK_" + inputName));
+        materials.add(Material.matchMaterial("BLUE_" + inputName));
+        materials.add(Material.matchMaterial("BROWN_" + inputName));
+        materials.add(Material.matchMaterial("CYAN_" + inputName));
+        materials.add(Material.matchMaterial("GRAY_" + inputName));
+        materials.add(Material.matchMaterial("GREEN_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_BLUE_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_GRAY_" + inputName));
+        materials.add(Material.matchMaterial("LIME_" + inputName));
+        materials.add(Material.matchMaterial("MAGENTA_" + inputName));
+        materials.add(Material.matchMaterial("ORANGE_" + inputName));
+        materials.add(Material.matchMaterial("PINK_" + inputName));
+        materials.add(Material.matchMaterial("PURPLE_" + inputName));
+        materials.add(Material.matchMaterial("RED_" + inputName));
+        materials.add(Material.matchMaterial("WHITE_" + inputName));
+        materials.add(Material.matchMaterial("YELLOW_" + inputName));
 
         recipe.addIngredient(new RecipeChoice.MaterialChoice(materials));
         recipe.addIngredient(inputDye);
@@ -118,48 +118,48 @@ public class UniversalDyeing extends AbstractCraftingTweak {
     }
 
     public void registerBedRecipeTypes(String inputName) {
-        newBedRecipe("black_", inputName, Material.BLACK_DYE, Material.valueOf("BLACK_" + inputName));
-        newBedRecipe("blue_", inputName, Material.BLUE_DYE, Material.valueOf("BLUE_" + inputName));
-        newBedRecipe("brown_", inputName, Material.BROWN_DYE, Material.valueOf("BROWN_" + inputName));
-        newBedRecipe("cyan_", inputName, Material.CYAN_DYE, Material.valueOf("CYAN_" + inputName));
-        newBedRecipe("gray_", inputName, Material.GRAY_DYE, Material.valueOf("GRAY_" + inputName));
-        newBedRecipe("green_", inputName, Material.GREEN_DYE, Material.valueOf("GREEN_" + inputName));
-        newBedRecipe("light_blue_", inputName, Material.LIGHT_BLUE_DYE, Material.valueOf("LIGHT_BLUE_" + inputName));
-        newBedRecipe("light_gray_", inputName, Material.LIGHT_GRAY_DYE, Material.valueOf("LIGHT_GRAY_" + inputName));
-        newBedRecipe("lime_", inputName, Material.LIME_DYE, Material.valueOf("LIME_" + inputName));
-        newBedRecipe("magenta_", inputName, Material.MAGENTA_DYE, Material.valueOf("MAGENTA_" + inputName));
-        newBedRecipe("orange_", inputName, Material.ORANGE_DYE, Material.valueOf("ORANGE_" + inputName));
-        newBedRecipe("pink_", inputName, Material.PINK_DYE, Material.valueOf("PINK_" + inputName));
-        newBedRecipe("purple_", inputName, Material.PURPLE_DYE, Material.valueOf("PURPLE_" + inputName));
-        newBedRecipe("red_", inputName, Material.RED_DYE, Material.valueOf("RED_" + inputName));
-        newBedRecipe("white_", inputName, Material.WHITE_DYE, Material.valueOf("WHITE_" + inputName));
-        newBedRecipe("yellow_", inputName, Material.YELLOW_DYE, Material.valueOf("YELLOW_" + inputName));
+        newBedRecipe("black_", inputName, Material.BLACK_DYE, Material.matchMaterial("BLACK_" + inputName));
+        newBedRecipe("blue_", inputName, Material.BLUE_DYE, Material.matchMaterial("BLUE_" + inputName));
+        newBedRecipe("brown_", inputName, Material.BROWN_DYE, Material.matchMaterial("BROWN_" + inputName));
+        newBedRecipe("cyan_", inputName, Material.CYAN_DYE, Material.matchMaterial("CYAN_" + inputName));
+        newBedRecipe("gray_", inputName, Material.GRAY_DYE, Material.matchMaterial("GRAY_" + inputName));
+        newBedRecipe("green_", inputName, Material.GREEN_DYE, Material.matchMaterial("GREEN_" + inputName));
+        newBedRecipe("light_blue_", inputName, Material.LIGHT_BLUE_DYE, Material.matchMaterial("LIGHT_BLUE_" + inputName));
+        newBedRecipe("light_gray_", inputName, Material.LIGHT_GRAY_DYE, Material.matchMaterial("LIGHT_GRAY_" + inputName));
+        newBedRecipe("lime_", inputName, Material.LIME_DYE, Material.matchMaterial("LIME_" + inputName));
+        newBedRecipe("magenta_", inputName, Material.MAGENTA_DYE, Material.matchMaterial("MAGENTA_" + inputName));
+        newBedRecipe("orange_", inputName, Material.ORANGE_DYE, Material.matchMaterial("ORANGE_" + inputName));
+        newBedRecipe("pink_", inputName, Material.PINK_DYE, Material.matchMaterial("PINK_" + inputName));
+        newBedRecipe("purple_", inputName, Material.PURPLE_DYE, Material.matchMaterial("PURPLE_" + inputName));
+        newBedRecipe("red_", inputName, Material.RED_DYE, Material.matchMaterial("RED_" + inputName));
+        newBedRecipe("white_", inputName, Material.WHITE_DYE, Material.matchMaterial("WHITE_" + inputName));
+        newBedRecipe("yellow_", inputName, Material.YELLOW_DYE, Material.matchMaterial("YELLOW_" + inputName));
     }
 
 
     public void newClearRecipe(String inputName) {
         NamespacedKey key = Key.get("clear_" + inputName.toLowerCase() + "_universal");
 
-        ShapelessRecipe recipe = new ShapelessRecipe(key, new ItemStack(Material.valueOf(inputName)));
+        ShapelessRecipe recipe = new ShapelessRecipe(key, new ItemStack(Material.matchMaterial(inputName)));
 
 
         List<Material> materials = new ArrayList<>();
-        materials.add(Material.valueOf("BLACK_" + inputName));
-        materials.add(Material.valueOf("BLUE_" + inputName));
-        materials.add(Material.valueOf("BROWN_" + inputName));
-        materials.add(Material.valueOf("CYAN_" + inputName));
-        materials.add(Material.valueOf("GRAY_" + inputName));
-        materials.add(Material.valueOf("GREEN_" + inputName));
-        materials.add(Material.valueOf("LIGHT_BLUE_" + inputName));
-        materials.add(Material.valueOf("LIGHT_GRAY_" + inputName));
-        materials.add(Material.valueOf("LIME_" + inputName));
-        materials.add(Material.valueOf("MAGENTA_" + inputName));
-        materials.add(Material.valueOf("ORANGE_" + inputName));
-        materials.add(Material.valueOf("PINK_" + inputName));
-        materials.add(Material.valueOf("PURPLE_" + inputName));
-        materials.add(Material.valueOf("RED_" + inputName));
-        materials.add(Material.valueOf("WHITE_" + inputName));
-        materials.add(Material.valueOf("YELLOW_" + inputName));
+        materials.add(Material.matchMaterial("BLACK_" + inputName));
+        materials.add(Material.matchMaterial("BLUE_" + inputName));
+        materials.add(Material.matchMaterial("BROWN_" + inputName));
+        materials.add(Material.matchMaterial("CYAN_" + inputName));
+        materials.add(Material.matchMaterial("GRAY_" + inputName));
+        materials.add(Material.matchMaterial("GREEN_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_BLUE_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_GRAY_" + inputName));
+        materials.add(Material.matchMaterial("LIME_" + inputName));
+        materials.add(Material.matchMaterial("MAGENTA_" + inputName));
+        materials.add(Material.matchMaterial("ORANGE_" + inputName));
+        materials.add(Material.matchMaterial("PINK_" + inputName));
+        materials.add(Material.matchMaterial("PURPLE_" + inputName));
+        materials.add(Material.matchMaterial("RED_" + inputName));
+        materials.add(Material.matchMaterial("WHITE_" + inputName));
+        materials.add(Material.matchMaterial("YELLOW_" + inputName));
 
         recipe.addIngredient(new RecipeChoice.MaterialChoice(materials));
         recipe.addIngredient(Material.ICE);
@@ -170,26 +170,26 @@ public class UniversalDyeing extends AbstractCraftingTweak {
     public void newClearStainedRecipe(String inputName) {
         NamespacedKey key = Key.get("clear_" + inputName.toLowerCase() + "_universal");
 
-        ShapelessRecipe recipe = new ShapelessRecipe(key, new ItemStack(Material.valueOf(inputName)));
+        ShapelessRecipe recipe = new ShapelessRecipe(key, new ItemStack(Material.matchMaterial(inputName)));
 
 
         List<Material> materials = new ArrayList<>();
-        materials.add(Material.valueOf("BLACK_STAINED_" + inputName));
-        materials.add(Material.valueOf("BLUE_STAINED_" + inputName));
-        materials.add(Material.valueOf("BROWN_STAINED_" + inputName));
-        materials.add(Material.valueOf("CYAN_STAINED_" + inputName));
-        materials.add(Material.valueOf("GRAY_STAINED_" + inputName));
-        materials.add(Material.valueOf("GREEN_STAINED_" + inputName));
-        materials.add(Material.valueOf("LIGHT_BLUE_STAINED_" + inputName));
-        materials.add(Material.valueOf("LIGHT_GRAY_STAINED_" + inputName));
-        materials.add(Material.valueOf("LIME_STAINED_" + inputName));
-        materials.add(Material.valueOf("MAGENTA_STAINED_" + inputName));
-        materials.add(Material.valueOf("ORANGE_STAINED_" + inputName));
-        materials.add(Material.valueOf("PINK_STAINED_" + inputName));
-        materials.add(Material.valueOf("PURPLE_STAINED_" + inputName));
-        materials.add(Material.valueOf("RED_STAINED_" + inputName));
-        materials.add(Material.valueOf("WHITE_STAINED_" + inputName));
-        materials.add(Material.valueOf("YELLOW_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("BLACK_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("BLUE_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("BROWN_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("CYAN_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("GRAY_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("GREEN_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_BLUE_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("LIGHT_GRAY_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("LIME_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("MAGENTA_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("ORANGE_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("PINK_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("PURPLE_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("RED_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("WHITE_STAINED_" + inputName));
+        materials.add(Material.matchMaterial("YELLOW_STAINED_" + inputName));
 
         recipe.addIngredient(new RecipeChoice.MaterialChoice(materials));
         recipe.addIngredient(Material.ICE);

--- a/src/main/java/me/teakivy/teakstweaks/packs/alwaysdrop/AlwaysDrop.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/alwaysdrop/AlwaysDrop.java
@@ -8,24 +8,30 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.List;
+import java.util.HashSet;
 
 public class AlwaysDrop extends BasePack {
 
+    private final HashSet<Material> alwaysDropBlocks;
+
     public AlwaysDrop() {
         super(TTPack.ALWAYS_DROP, Material.ENDER_CHEST);
+        alwaysDropBlocks = new HashSet<>();
+        for (String block : getConfig().getStringList("blocks")) {
+            Material item = Material.matchMaterial(block);
+            if (item != null && item.isBlock()) {
+                alwaysDropBlocks.add(item);
+            }
+        }
     }
 
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         if (event.isCancelled()) return;
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) return;
-        List<String> blockList = getConfig().getStringList("blocks");
-        for (String block : blockList) {
-            if (event.getBlock().getType().toString().equalsIgnoreCase(block)) {
-                event.setDropItems(false);
-                event.getBlock().getWorld().dropItemNaturally(event.getBlock().getLocation(), new ItemStack(event.getBlock().getType()));
-            }
+        if (alwaysDropBlocks.contains(event.getBlock().getType())) {
+            event.setDropItems(false);
+            event.getBlock().getWorld().dropItemNaturally(event.getBlock().getLocation(), new ItemStack(event.getBlock().getType()));
         }
     }
 }

--- a/src/main/java/me/teakivy/teakstweaks/packs/cauldronconcrete/CauldronConcrete.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/cauldronconcrete/CauldronConcrete.java
@@ -44,7 +44,7 @@ public class CauldronConcrete extends BasePack {
 
         event.getItem().setAmount(event.getItem().getAmount() - 1);
 
-        ItemStack newItem = new ItemStack(Material.valueOf(event.getItem().getType().name().replace("_CONCRETE_POWDER", "_CONCRETE")));
+        ItemStack newItem = new ItemStack(Material.matchMaterial(event.getItem().getType().name().replace("_CONCRETE_POWDER", "_CONCRETE")));
 
         event.getPlayer().getInventory().addItem(newItem);
     }

--- a/src/main/java/me/teakivy/teakstweaks/packs/elevators/Elevators.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/elevators/Elevators.java
@@ -17,16 +17,23 @@ import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.UUID;
 
 public class Elevators extends BasePack {
     private static final HashMap<UUID, Long> cooldown = new HashMap<>();
+    private final HashSet<Material> elevatorBlocks;
 
     public Elevators() {
         super(TTPack.ELEVATORS, Material.ENDER_PEARL);
+        elevatorBlocks = new HashSet<>();
+        for (String block : getConfig().getStringList("elevator-blocks")) {
+            Material item = Material.matchMaterial(block);
+            if (item != null && item.isBlock()) {
+                elevatorBlocks.add(item);
+            }
+        }
     }
 
     @EventHandler
@@ -40,7 +47,7 @@ public class Elevators extends BasePack {
         new BukkitRunnable() {
             @Override
             public void run() {
-                if (!getElevatorMaterials().contains(event.getItemDrop().getLocation().add(0, -1, 0).getBlock().getType())) return;
+                if (!elevatorBlocks.contains(event.getItemDrop().getLocation().add(0, -1, 0).getBlock().getType())) return;
                 if (event.getItemDrop().getItemStack().getAmount() != 1) return;
 
                 event.getItemDrop().remove();
@@ -54,7 +61,7 @@ public class Elevators extends BasePack {
     @EventHandler
     public void onBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
-        if (!getElevatorMaterials().contains(event.getBlock().getType())) return;
+        if (!elevatorBlocks.contains(event.getBlock().getType())) return;
         if (!isElevator(block)) return;
 
         for (Entity entity : block.getWorld().getNearbyEntities(block.getLocation().add(.5, 1, .5), .4, .8, .4)) {
@@ -154,15 +161,6 @@ public class Elevators extends BasePack {
             return next;
         }
         return next;
-    }
-
-    private List<Material> getElevatorMaterials() {
-        List<Material> elevatorMaterials = new ArrayList<>();
-        for (String block : getConfig().getStringList("elevator-blocks")) {
-            elevatorMaterials.add(Material.valueOf(block));
-        }
-
-        return elevatorMaterials;
     }
 
     private boolean checkBlock(Block b1, Block b2) {

--- a/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/fixeditemframes/FixedItemFrames.java
@@ -26,7 +26,7 @@ public class FixedItemFrames extends BasePack {
 		if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
 			if (!event.getPlayer().isSneaking()) return;
 			ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
-			if (item.getType() != Material.valueOf(getConfig().getString("item-to-use"))) return;
+			if (item.getType() != Material.matchMaterial(getConfig().getString("item-to-use"))) return;
 			event.setCancelled(true);
 
 			event.getPlayer().getInventory().setItemInMainHand(ItemUtils.handleUse(item, event.getPlayer()));

--- a/src/main/java/me/teakivy/teakstweaks/packs/instamine/InstaMine.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/instamine/InstaMine.java
@@ -3,6 +3,7 @@ package me.teakivy.teakstweaks.packs.instamine;
 import me.teakivy.teakstweaks.packs.BasePack;
 import me.teakivy.teakstweaks.utils.permission.Permission;
 import me.teakivy.teakstweaks.utils.register.TTPack;
+
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
@@ -13,10 +14,21 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.util.HashSet;
+
 public class InstaMine extends BasePack {
+
+    private final HashSet<Material> instaMineBlocks;
 
     public InstaMine() {
         super(TTPack.INSTA_MINE, Material.DEEPSLATE);
+        instaMineBlocks = new HashSet<>();
+        for (String block : getConfig().getStringList("blocks")) {
+            Material item = Material.matchMaterial(block);
+            if (item != null && item.isBlock()) {
+                instaMineBlocks.add(item);
+            }
+        }
     }
 
     @EventHandler
@@ -25,14 +37,7 @@ public class InstaMine extends BasePack {
         Player player = e.getPlayer();
         ItemStack item = e.getItemInHand();
         Block block = e.getBlock();
-        boolean isInstant = false;
-        for (String blocks : getConfig().getStringList("blocks")) {
-            if (blocks.equalsIgnoreCase(block.getType().name())) {
-                isInstant = true;
-                break;
-            }
-        }
-        if (!isInstant) return;
+        if (!instaMineBlocks.contains(block.getType())) return;
 
         if (item.getType().equals(Material.NETHERITE_PICKAXE) && hasHasteTwo(player) && isEfficiencyFive(item)) {
             e.setInstaBreak(true);

--- a/src/main/java/me/teakivy/teakstweaks/packs/invisibleitemframes/InvisibleItemFrames.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/invisibleitemframes/InvisibleItemFrames.java
@@ -26,7 +26,7 @@ public class InvisibleItemFrames extends BasePack {
         if (event.getRightClicked().getType() == EntityType.ITEM_FRAME || event.getRightClicked().getType() == EntityType.GLOW_ITEM_FRAME) {
             if (!event.getPlayer().isSneaking()) return;
             ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
-            if (item.getType() != Material.valueOf(getConfig().getString("item-to-use"))) return;
+            if (item.getType() != Material.matchMaterial(getConfig().getString("item-to-use"))) return;
             event.setCancelled(true);
 
             event.getPlayer().getInventory().setItemInMainHand(ItemUtils.handleUse(item, event.getPlayer()));

--- a/src/main/java/me/teakivy/teakstweaks/utils/miniblock/MiniBlockUtils.java
+++ b/src/main/java/me/teakivy/teakstweaks/utils/miniblock/MiniBlockUtils.java
@@ -41,7 +41,7 @@ public class MiniBlockUtils {
 
                 String name = (String) mini_block_map.get("name");
                 String texture = (String) mini_block_map.get("texture");
-                Material material = Material.valueOf(mini_block_map.get("id").toString().toUpperCase());
+                Material material = Material.matchMaterial(mini_block_map.get("id").toString().toUpperCase());
 
                 miniBlocks.add(new MiniBlockTrade(name, texture, material));
             }


### PR DESCRIPTION
- Replaced `Material.valueOf()` with `Material.matchMaterial()`. This makes material lookups case-insensitive.
- Switched from `List` iteration to `HashSet.contains()` for material checks in event handlers (`AlwaysDrop`, `Elevators`, `InstaMine`, etc.). This improves performance as the lookup complexity is now `O(1)` instead of `O(n)`.